### PR TITLE
Use SFU provided ICE servers

### DIFF
--- a/components/livekit/core/engine.c
+++ b/components/livekit/core/engine.c
@@ -502,25 +502,17 @@ static inline size_t map_ice_servers(
 
 static bool establish_peer_connections(engine_t *eng, livekit_pb_join_response_t *join)
 {
-    esp_peer_ice_server_cfg_t server_list[] = {
-        { .stun_url = "stun:stun.l.google.com:19302" },
-        { .stun_url = "stun:stun1.l.google.com:19302" },
-        { .stun_url = "stun:stun2.l.google.com:19302" }
-    };
-    int server_count = sizeof(server_list) / sizeof(server_list[0]);
-
-    // TODO: Replace the above with the following to set the ICE servers dynamically:
-    // esp_peer_ice_server_cfg_t server_list[CONFIG_LK_MAX_ICE_SERVERS];
-    // int server_count = map_ice_servers(
-    //     join->ice_servers,
-    //     join->ice_servers_count,
-    //     server_list,
-    //     sizeof(server_list) / sizeof(server_list[0])
-    // );
-    // if (server_count < 1) {
-    //     ESP_LOGW(TAG, "No ICE servers available");
-    //     return false;
-    // }
+    esp_peer_ice_server_cfg_t server_list[CONFIG_LK_MAX_ICE_SERVERS];
+    int server_count = map_ice_servers(
+        join->ice_servers,
+        join->ice_servers_count,
+        server_list,
+        sizeof(server_list) / sizeof(server_list[0])
+    );
+    if (server_count < 1) {
+        ESP_LOGW(TAG, "No ICE servers available");
+        return false;
+    }
 
     peer_options_t options = {
         .force_relay      = join->client_configuration.force_relay

--- a/components/livekit/core/peer.c
+++ b/components/livekit/core/peer.c
@@ -288,13 +288,11 @@ peer_err_t peer_create(peer_handle_t *handle, peer_options_t *options)
 
      // Configuration for the default peer implementation
     esp_peer_default_cfg_t default_peer_cfg = {
-        .agent_recv_timeout = 10000,
         .data_ch_cfg = {
             .cache_timeout = 5000,
             .send_cache_size = 100 * 1024,
             .recv_cache_size = 100 * 1024
         }
-        // TODO: Set options
     };
     esp_peer_media_dir_t audio_dir = get_media_direction(options->media->audio_dir, peer->options.role);
     esp_peer_media_dir_t video_dir = get_media_direction(options->media->video_dir, peer->options.role);

--- a/components/livekit/idf_component.yml
+++ b/components/livekit/idf_component.yml
@@ -8,8 +8,8 @@ version: 0.2.0
 dependencies:
   idf: ">=5.4"
   espressif/esp_websocket_client: ~1.5.0
-  espressif/esp_codec_dev: "~1.4"
-  espressif/esp_capture: "~0.7"
+  espressif/esp_codec_dev: ~1.4
+  espressif/esp_capture: ~0.7
   espressif/esp_peer: ~1.2.3
   media_lib_sal:
     path: ../third_party/esp-webrtc-solution/components/media_lib_sal

--- a/components/livekit/idf_component.yml
+++ b/components/livekit/idf_component.yml
@@ -10,7 +10,7 @@ dependencies:
   espressif/esp_websocket_client: ~1.5.0
   espressif/esp_codec_dev: "~1.4"
   espressif/esp_capture: "~0.7"
-  espressif/esp_peer: ^1.2.3
+  espressif/esp_peer: ~1.2.3
   media_lib_sal:
     path: ../third_party/esp-webrtc-solution/components/media_lib_sal
   nanopb:


### PR DESCRIPTION
Previously, an issue in _esp_peer_ caused connection establishment to fail when using SFU provided TURN servers. With _esp_peer_ v1.2.4, this issue is addressed.