### PR TITLE
Subscribe to tracks in join response

### DIFF
--- a/components/livekit/core/engine.h
+++ b/components/livekit/core/engine.h
@@ -35,6 +35,7 @@ typedef enum {
     ENGINE_ERR_RTC         = -4,
     ENGINE_ERR_MEDIA       = -5,
     ENGINE_ERR_OTHER       = -6,
+    ENGINE_ERR_MAX_SUB     = -7, // No more subscriptions allowed.
     // TODO: Add more error cases as needed
 } engine_err_t;
 


### PR DESCRIPTION
Addresses a bug where remote tracks that have already been published prior to joining are not subscribed to.

Fixes #49 