### PR TITLE
Support busy ESP32 by a config for engine task stack size

### DIFF
--- a/components/livekit/Kconfig
+++ b/components/livekit/Kconfig
@@ -12,6 +12,9 @@ menu "LiveKit"
     config LK_ENGINE_QUEUE_SIZE
         int "Number of engine events to queue"
         default 32
+    config LK_ENGINE_TASK_STACK_SIZE
+        int "Stack size for LiveKit engine task"
+        default 4096
     config LK_PUB_INTERVAL_MS
         int "How often to capture and send AV frames"
         default 20

--- a/components/livekit/core/engine.c
+++ b/components/livekit/core/engine.c
@@ -1128,7 +1128,7 @@ engine_handle_t engine_init(const engine_options_t *options)
     if (xTaskCreate(
         engine_task,
         "engine_task",
-        4096,
+        CONFIG_LK_ENGINE_TASK_STACK_SIZE,
         (void *)eng,
         5,
         &eng->task_handle


### PR DESCRIPTION
On [SAT1 PCB Dev Kit](https://futureproofhomes.net/products/satellite1-pcb-dev-kit), hardcoded 4096-byte stack caused overflows after minutes when running alongside other tasks. Increasing to 8192 fixed it.

**Changes:**
- Added `LK_ENGINE_TASK_STACK_SIZE` (default 4096).
- Use `CONFIG_LK_ENGINE_TASK_STACK_SIZE` in `xTaskCreate`.

Tested stable on SAT1 at 8192; default unchanged.