### PR TITLE
chore: Upgrade dependencies

### DIFF
--- a/components/livekit/idf_component.yml
+++ b/components/livekit/idf_component.yml
@@ -11,9 +11,9 @@ dependencies:
   idf: ">=5.4"
   espressif/esp_capture: { version: ~0.7, public: true }
   tempotian/av_render: { version: ~0.9.1, public: true }
-  tempotian/media_lib_sal: ~0.9.0
+  tempotian/media_lib_sal: ~0.9.1
   espressif/esp_peer: ~1.2.7
-  espressif/esp_websocket_client: ~1.6.0
+  espressif/esp_websocket_client: ~1.6.1
   livekit/khash: ~0.2.8
   livekit/nanopb: ~0.4.9
 files:


### PR DESCRIPTION
- espressif/esp_websocket_client → ~1.6.1
  - "Fix race conditions, memory leak, and data loss" ([23ca97d5](https://github.com/espressif/esp-protocols/commit/23ca97d5)) 
- tempotian/media_lib_sal → ~0.9.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions to latest stable releases for improved compatibility and security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->