### PR TITLE
Update espressif dependencies for ESP32-P4 and ESP32-H2 compatibility

### DIFF
--- a/components/livekit/examples/minimal_video/main/idf_component.yml
+++ b/components/livekit/examples/minimal_video/main/idf_component.yml
@@ -10,9 +10,9 @@ dependencies:
     version: ~0.2.0
     override_path: ../../../../example_utils
   tempotian/codec_board: ~1.0.0
-  # The following components are required to connect to WiFi for ESP32-P4-based
-  # development board that supports WiFi. The versions here are known to work with
-  # the ESP32-P4-Function-EV-Board out-of-the-box.
+  # The following components are required to connect to WiFi for ESP32-P4 and
+  # ESP32-H2-based development boards that support WiFi. The versions here are
+  # known to work with the ESP32-P4-Function-EV-Board out-of-the-box.
   espressif/esp_wifi_remote:
     version: ">=0.10,<2.0"
     rules:


### PR DESCRIPTION
On newer ESP32-P4 devkits, the esp32 c6 slave come with a higher firmware version, which isn't compatible with current dependencies.

This updates the dependencies so the example can be compatible in such cases.