### PR TITLE
fix: bump engine_task default stack to 8192

### DIFF
--- a/components/livekit/Kconfig
+++ b/components/livekit/Kconfig
@@ -14,7 +14,7 @@ menu "LiveKit"
         default 32
     config LK_ENGINE_TASK_STACK_SIZE
         int "Stack size for LiveKit engine task"
-        default 4096
+        default 8192
     config LK_PUB_INTERVAL_MS
         int "How often to capture and send AV frames"
         default 20


### PR DESCRIPTION
The default stack of 4096 for `engine_task` isn't enough when DTLS-SRTP kicks in. mbedTLS eats through the stack during self-signed cert generation and you get a FreeRTOS stack overflow panic before the connection even completes.

The backtrace looks like:
```
dtls_srtp_selfsign_cert → dtls_srtp_init → peer_open → engine_task
```

Bumping to 8192 fixes it. Tested on an ESP32-S3 (octal PSRAM, ESP-IDF 5.5.2).

Only touches the Kconfig default — no code changes. Users who already override `LK_ENGINE_TASK_STACK_SIZE` in their sdkconfig aren't affected..