### PR TITLE
Improve resource cleanup

### DIFF
--- a/components/livekit/core/engine.c
+++ b/components/livekit/core/engine.c
@@ -1214,10 +1214,9 @@ engine_err_t engine_destroy(engine_handle_t handle)
         xTimerDelete(eng->timer, portMAX_DELAY);
         eng->timer = NULL;
     }
-    if (eng->event_queue != NULL) {
-        vQueueDelete(eng->event_queue);
-        eng->event_queue = NULL;
-    }
+
+    media_stream_end(eng);
+
     if (eng->signal_handle != NULL) {
         signal_destroy(eng->signal_handle);
         eng->signal_handle = NULL;
@@ -1229,6 +1228,12 @@ engine_err_t engine_destroy(engine_handle_t handle)
     if (eng->sub_peer_handle != NULL) {
         peer_destroy(eng->sub_peer_handle);
         eng->sub_peer_handle = NULL;
+    }
+
+    if (eng->event_queue != NULL) {
+        flush_event_queue(eng);
+        vQueueDelete(eng->event_queue);
+        eng->event_queue = NULL;
     }
     SAFE_FREE(eng->server_url);
     SAFE_FREE(eng->token);

--- a/components/livekit/core/livekit.c
+++ b/components/livekit/core/livekit.c
@@ -290,6 +290,7 @@ livekit_err_t livekit_room_destroy(livekit_room_handle_t handle)
     }
     livekit_room_close(handle);
     engine_destroy(room->engine);
+    rpc_manager_destroy(room->rpc_manager);
     data_stream_reader_destroy(room->data_stream_reader);
     data_stream_writer_destroy(room->data_stream_writer);
     free(room);

--- a/components/livekit/core/rpc_manager.c
+++ b/components/livekit/core/rpc_manager.c
@@ -195,6 +195,9 @@ rpc_manager_err_t rpc_manager_destroy(rpc_manager_handle_t handle)
         return RPC_MANAGER_ERR_INVALID_ARG;
     }
     rpc_manager_t *rpc = (rpc_manager_t *)handle;
+    if (rpc->handlers != NULL) {
+        kh_destroy(handlers, rpc->handlers);
+    }
     free(rpc);
     return RPC_MANAGER_ERR_NONE;
 }

--- a/components/livekit/core/signaling.c
+++ b/components/livekit/core/signaling.c
@@ -285,6 +285,10 @@ signal_err_t signal_destroy(signal_handle_t handle)
         return SIGNAL_ERR_INVALID_ARG;
     }
     signal_t *sg = (signal_t *)handle;
+
+    if (sg->ws != NULL) {
+        esp_websocket_client_stop(sg->ws);
+    }
     if (sg->ping_interval_timer != NULL) {
         xTimerDelete(sg->ping_interval_timer, portMAX_DELAY);
     }


### PR DESCRIPTION
Summary of changes:
- Address two issues that can lead to a crash when destroying a room
- Fix memory leak by properly freeing RPC manager