### PR TITLE
Upgrade vendored nanopb to 0.4.9.2

### DIFF
--- a/components/third_party/nanopb/idf_component.yml
+++ b/components/third_party/nanopb/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.4.9"
+version: "0.4.9~2"
 description: Protocol buffer library for embedded systems.
 url: https://jpa.kapsi.fi/nanopb/
 repository: https://github.com/nanopb/nanopb/

--- a/components/third_party/nanopb/include/pb.h
+++ b/components/third_party/nanopb/include/pb.h
@@ -28,9 +28,6 @@
 /* Disable support for error messages in order to save some code space. */
 /* #define PB_NO_ERRMSG 1 */
 
-/* Disable checks to ensure sub-message encoded size is consistent when re-run. */
-/* #define PB_NO_ENCODE_SIZE_CHECK 1 */
-
 /* Disable support for custom streams (support only memory buffers). */
 /* #define PB_BUFFER_ONLY 1 */
 
@@ -60,6 +57,9 @@
 /* #define PB_C99_STATIC_ASSERT 1 */
 /* #define PB_NO_STATIC_ASSERT 1 */
 
+/* Limit for depth of recursive message structure */
+/* #define PB_MESSAGE_NESTING_MAX 10 */
+
 /******************************************************************
  * You usually don't need to change anything below this line.     *
  * Feel free to look around and use the defined macros, though.   *
@@ -68,7 +68,7 @@
 
 /* Version of the nanopb library. Just in case you want to check it in
  * your own program. */
-#define NANOPB_VERSION "nanopb-1.0.0-dev"
+#define NANOPB_VERSION "nanopb-0.4.9.2"
 
 /* Include all the system headers needed by nanopb. You will need the
  * definitions of the following:
@@ -127,19 +127,6 @@ extern "C" {
 #   define PB_PACKED_STRUCT_START
 #   define PB_PACKED_STRUCT_END
 #   define pb_packed
-#endif
-
-/* Define for explicitly not inlining a given function */
-#if defined(__GNUC__) || defined(__clang__)
-    /* For GCC and clang */
-#   define pb_noinline __attribute__((noinline))
-#elif defined(__ICCARM__) || defined(__CC_ARM)
-    /* For IAR ARM and Keil MDK-ARM compilers */
-#   define pb_noinline
-#elif defined(_MSC_VER) && (_MSC_VER >= 1500)
-#   define pb_noinline __declspec(noinline)
-#else
-#   define pb_noinline
 #endif
 
 /* Detect endianness */

--- a/components/third_party/nanopb/include/pb_decode.h
+++ b/components/third_party/nanopb/include/pb_decode.h
@@ -54,12 +54,24 @@ struct pb_istream_s
     /* Pointer to constant (ROM) string when decoding function returns error */
     const char *errmsg;
 #endif
+
+#ifdef PB_MESSAGE_NESTING_MAX
+    pb_size_t depth;
+#endif
 };
 
-#ifndef PB_NO_ERRMSG
-#define PB_ISTREAM_EMPTY {0,0,0,0}
+#ifdef PB_MESSAGE_NESTING_MAX
+# ifndef PB_NO_ERRMSG
+#  define PB_ISTREAM_EMPTY {0,0,0,0,0}
+# else
+#  define PB_ISTREAM_EMPTY {0,0,0,0}
+# endif
 #else
-#define PB_ISTREAM_EMPTY {0,0,0}
+# ifndef PB_NO_ERRMSG
+#  define PB_ISTREAM_EMPTY {0,0,0,0}
+# else
+#  define PB_ISTREAM_EMPTY {0,0,0}
+# endif
 #endif
 
 /***************************

--- a/components/third_party/nanopb/src/pb_decode.c
+++ b/components/third_party/nanopb/src/pb_decode.c
@@ -23,6 +23,7 @@
  **************************************/
 
 static bool checkreturn buf_read(pb_istream_t *stream, pb_byte_t *buf, size_t count);
+static bool checkreturn pb_decode_varint32_eof(pb_istream_t *stream, uint32_t *dest, bool *eof);
 static bool checkreturn read_raw_value(pb_istream_t *stream, pb_wire_type_t wire_type, pb_byte_t *buf, size_t *size);
 static bool checkreturn decode_basic_field(pb_istream_t *stream, pb_wire_type_t wire_type, pb_field_iter_t *field);
 static bool checkreturn decode_static_field(pb_istream_t *stream, pb_wire_type_t wire_type, pb_field_iter_t *field);
@@ -160,21 +161,31 @@ pb_istream_t pb_istream_from_buffer(const pb_byte_t *buf, size_t msglen)
 #ifndef PB_NO_ERRMSG
     stream.errmsg = NULL;
 #endif
+#ifdef PB_MESSAGE_NESTING_MAX
+    stream.depth = 0;
+#endif
     return stream;
 }
-
 
 /********************
  * Helper functions *
  ********************/
 
-bool checkreturn pb_decode_varint32(pb_istream_t *stream, uint32_t *dest)
+static bool checkreturn pb_decode_varint32_eof(pb_istream_t *stream, uint32_t *dest, bool *eof)
 {
     pb_byte_t byte;
     uint32_t result;
     
     if (!pb_readbyte(stream, &byte))
     {
+        if (stream->bytes_left == 0)
+        {
+            if (eof)
+            {
+                *eof = true;
+            }
+        }
+
         return false;
     }
     
@@ -224,6 +235,11 @@ bool checkreturn pb_decode_varint32(pb_istream_t *stream, uint32_t *dest)
    
    *dest = result;
    return true;
+}
+
+bool checkreturn pb_decode_varint32(pb_istream_t *stream, uint32_t *dest)
+{
+    return pb_decode_varint32_eof(stream, dest, NULL);
 }
 
 #ifndef PB_WITHOUT_64BIT
@@ -281,32 +297,9 @@ bool checkreturn pb_decode_tag(pb_istream_t *stream, pb_wire_type_t *wire_type, 
     *eof = false;
     *wire_type = (pb_wire_type_t) 0;
     *tag = 0;
-
-    if (stream->bytes_left == 0)
+    
+    if (!pb_decode_varint32_eof(stream, &temp, eof))
     {
-        *eof = true;
-        return false;
-    }
-
-    if (!pb_decode_varint32(stream, &temp))
-    {
-#ifndef PB_BUFFER_ONLY
-        /* Workaround for issue #1017
-         *
-         * Callback streams don't set bytes_left to 0 on eof until after being called by pb_decode_varint32,
-         * which results in "io error" being raised. This contrasts the behavior of buffer streams who raise
-         * no error on eof as bytes_left is already 0 on entry. This causes legitimate errors (e.g. missing
-         * required fields) to be incorrectly reported by callback streams.
-         */
-        if (stream->callback != buf_read && stream->bytes_left == 0)
-        {
-#ifndef PB_NO_ERRMSG
-            if (strcmp(stream->errmsg, "io error") == 0)
-                stream->errmsg = NULL;
-#endif
-            *eof = true;
-        }
-#endif
         return false;
     }
     
@@ -323,11 +316,6 @@ bool checkreturn pb_skip_field(pb_istream_t *stream, pb_wire_type_t wire_type)
         case PB_WT_64BIT: return pb_read(stream, NULL, 8);
         case PB_WT_STRING: return pb_skip_string(stream);
         case PB_WT_32BIT: return pb_read(stream, NULL, 4);
-	case PB_WT_PACKED: 
-            /* Calling pb_skip_field with a PB_WT_PACKED is an error.
-             * Explicitly handle this case and fallthrough to default to avoid
-             * compiler warnings.
-             */
         default: PB_RETURN_ERROR(stream, "invalid wire_type");
     }
 }
@@ -367,12 +355,6 @@ static bool checkreturn read_raw_value(pb_istream_t *stream, pb_wire_type_t wire
              * compiler warnings.
              */
 
-	case PB_WT_PACKED: 
-            /* Calling read_raw_value with a PB_WT_PACKED is an error.
-             * Explicitly handle this case and fallthrough to default to avoid
-             * compiler warnings.
-             */
-
         default: PB_RETURN_ERROR(stream, "invalid wire_type");
     }
 }
@@ -390,6 +372,12 @@ bool checkreturn pb_make_string_substream(pb_istream_t *stream, pb_istream_t *su
     if (substream->bytes_left < size)
         PB_RETURN_ERROR(stream, "parent stream too short");
     
+#ifdef PB_MESSAGE_NESTING_MAX
+    substream->depth++;
+    if (substream->depth > PB_MESSAGE_NESTING_MAX)
+        PB_RETURN_ERROR(stream, "max depth");
+#endif
+
     substream->bytes_left = (size_t)size;
     stream->bytes_left -= (size_t)size;
     return true;
@@ -772,6 +760,18 @@ static bool checkreturn decode_pointer_field(pb_istream_t *stream, pb_wire_type_
 
 static bool checkreturn decode_callback_field(pb_istream_t *stream, pb_wire_type_t wire_type, pb_field_iter_t *field)
 {
+    /* Clear any data that may have been decoded for another oneof field
+     * that has come before this callback field.
+     */
+    if (PB_HTYPE(field->type) == PB_HTYPE_ONEOF)
+    {
+        if (*(pb_size_t*)field->pSize != 0 && *(pb_size_t*)field->pSize != field->tag)
+        {
+            memset(field->pData, 0, (size_t)field->data_size);
+        }
+        *(pb_size_t*)field->pSize = field->tag;
+    }
+
     if (!field->descriptor->field_callback)
         return pb_skip_field(stream, wire_type);
 
@@ -1026,10 +1026,6 @@ static bool pb_message_set_to_defaults(pb_field_iter_t *iter)
 
 static bool checkreturn pb_decode_inner(pb_istream_t *stream, const pb_msgdesc_t *fields, void *dest_struct, unsigned int flags)
 {
-    /* If the message contains extension fields, the extension handlers
-     * are called when tag number is >= extension_range_start. This precheck
-     * is just for speed, and the handlers will check for precise match.
-     */
     uint32_t extension_range_start = 0;
     pb_extension_t *extensions = NULL;
 
@@ -1041,16 +1037,8 @@ static bool checkreturn pb_decode_inner(pb_istream_t *stream, const pb_msgdesc_t
     pb_size_t fixed_count_size = 0;
     pb_size_t fixed_count_total_size = 0;
 
-    /* Tag and wire type of next field from the input stream */
-    uint32_t tag;
-    pb_wire_type_t wire_type;
-    bool eof;
-
-    /* Track presence of required fields */
     pb_fields_seen_t fields_seen = {{0, 0}};
     const uint32_t allbits = ~(uint32_t)0;
-
-    /* Descriptor for the structure field matching the tag decoded from stream */
     pb_field_iter_t iter;
 
     if (pb_field_iter_begin(&iter, fields, dest_struct))
@@ -1062,13 +1050,24 @@ static bool checkreturn pb_decode_inner(pb_istream_t *stream, const pb_msgdesc_t
         }
     }
 
-    while (pb_decode_tag(stream, &wire_type, &tag, &eof))
+    while (stream->bytes_left)
     {
+        uint32_t tag;
+        pb_wire_type_t wire_type;
+        bool eof;
+
+        if (!pb_decode_tag(stream, &wire_type, &tag, &eof))
+        {
+            if (eof)
+                break;
+            else
+                return false;
+        }
+
         if (tag == 0)
         {
           if (flags & PB_DECODE_NULLTERMINATED)
           {
-            eof = true;
             break;
           }
           else
@@ -1149,12 +1148,6 @@ static bool checkreturn pb_decode_inner(pb_istream_t *stream, const pb_msgdesc_t
             return false;
     }
 
-    if (!eof)
-    {
-        /* pb_decode_tag() returned error before end of stream */
-        return false;
-    }
-
     /* Check that all elements of the last decoded fixed count field were present. */
     if (fixed_count_field != PB_SIZE_MAX &&
         fixed_count_size != fixed_count_total_size)
@@ -1225,7 +1218,16 @@ bool checkreturn pb_decode_ex(pb_istream_t *stream, const pb_msgdesc_t *fields, 
 
 bool checkreturn pb_decode(pb_istream_t *stream, const pb_msgdesc_t *fields, void *dest_struct)
 {
-    return pb_decode_ex(stream, fields, dest_struct, 0);
+    bool status;
+
+    status = pb_decode_inner(stream, fields, dest_struct, 0);
+
+#ifdef PB_ENABLE_MALLOC
+    if (!status)
+        pb_release(fields, dest_struct);
+#endif
+
+    return status;
 }
 
 #ifdef PB_ENABLE_MALLOC

--- a/components/third_party/nanopb/src/pb_encode.c
+++ b/components/third_party/nanopb/src/pb_encode.c
@@ -27,7 +27,7 @@ static bool checkreturn pb_check_proto3_default_value(const pb_field_iter_t *fie
 static bool checkreturn encode_basic_field(pb_ostream_t *stream, const pb_field_iter_t *field);
 static bool checkreturn encode_callback_field(pb_ostream_t *stream, const pb_field_iter_t *field);
 static bool checkreturn encode_field(pb_ostream_t *stream, pb_field_iter_t *field);
-static pb_noinline bool checkreturn encode_extension_field(pb_ostream_t *stream, const pb_field_iter_t *field);
+static bool checkreturn encode_extension_field(pb_ostream_t *stream, const pb_field_iter_t *field);
 static bool checkreturn default_extension_encoder(pb_ostream_t *stream, const pb_extension_t *extension);
 static bool checkreturn pb_encode_varint_32(pb_ostream_t *stream, uint32_t low, uint32_t high);
 static bool checkreturn pb_enc_bool(pb_ostream_t *stream, const pb_field_iter_t *field);
@@ -54,9 +54,18 @@ static bool checkreturn buf_write(pb_ostream_t *stream, const pb_byte_t *buf, si
 {
     pb_byte_t *dest = (pb_byte_t*)stream->state;
     stream->state = dest + count;
-    
-    memcpy(dest, buf, count * sizeof(pb_byte_t));
-    
+
+    /* Skip the copy if buf is NULL. Callers should not invoke this with NULL,
+     * but pb_write may pass NULL for sizing passes. Some compilers
+     * (e.g. picolibc/arm-zephyr-eabi GCC 12.2) emit a -Wnonnull warning
+     * against memcpy's nonnull argument even though count would be 0 in
+     * that case. See #1141.
+     */
+    if (buf != NULL)
+    {
+        memcpy(dest, buf, count * sizeof(pb_byte_t));
+    }
+
     return true;
 }
 
@@ -484,7 +493,7 @@ static bool checkreturn default_extension_encoder(pb_ostream_t *stream, const pb
 
 /* Walk through all the registered extensions and give them a chance
  * to encode themselves. */
-static pb_noinline bool checkreturn encode_extension_field(pb_ostream_t *stream, const pb_field_iter_t *field)
+static bool checkreturn encode_extension_field(pb_ostream_t *stream, const pb_field_iter_t *field)
 {
     const pb_extension_t *extension = *(const pb_extension_t* const *)field->pData;
 
@@ -725,10 +734,8 @@ bool checkreturn pb_encode_submessage(pb_ostream_t *stream, const pb_msgdesc_t *
 {
     /* First calculate the message size using a non-writing substream. */
     pb_ostream_t substream = PB_OSTREAM_SIZING;
-#if !defined(PB_NO_ENCODE_SIZE_CHECK) || PB_NO_ENCODE_SIZE_CHECK == 0
-    bool status;
     size_t size;
-#endif
+    bool status;
     
     if (!pb_encode(&substream, fields, src_struct))
     {
@@ -738,19 +745,17 @@ bool checkreturn pb_encode_submessage(pb_ostream_t *stream, const pb_msgdesc_t *
         return false;
     }
     
-    if (!pb_encode_varint(stream, (pb_uint64_t)substream.bytes_written))
+    size = substream.bytes_written;
+    
+    if (!pb_encode_varint(stream, (pb_uint64_t)size))
         return false;
     
     if (stream->callback == NULL)
-        return pb_write(stream, NULL, substream.bytes_written); /* Just sizing */
+        return pb_write(stream, NULL, size); /* Just sizing */
     
-    if (stream->bytes_written + substream.bytes_written > stream->max_size)
+    if (stream->bytes_written + size > stream->max_size)
         PB_RETURN_ERROR(stream, "stream full");
         
-#if defined(PB_NO_ENCODE_SIZE_CHECK) && PB_NO_ENCODE_SIZE_CHECK == 1
-    return pb_encode(stream, fields, src_struct);
-#else
-    size = substream.bytes_written;
     /* Use a substream to verify that a callback doesn't write more than
      * what it did the first time. */
     substream.callback = stream->callback;
@@ -771,9 +776,8 @@ bool checkreturn pb_encode_submessage(pb_ostream_t *stream, const pb_msgdesc_t *
     
     if (substream.bytes_written != size)
         PB_RETURN_ERROR(stream, "submsg size changed");
-
+    
     return status;
-#endif
 }
 
 /* Field encoders */


### PR DESCRIPTION
This [release](https://github.com/nanopb/nanopb/releases/tag/nanopb-0.4.9.2) addresses two security advisories:
- https://github.com/nanopb/nanopb/security/advisories/GHSA-p24j-vqcp-x988
- https://github.com/nanopb/nanopb/security/advisories/GHSA-9w99-4pfq-6396